### PR TITLE
Update with preliminary caaddr and caddr functions

### DIFF
--- a/org-to-xml.el
+++ b/org-to-xml.el
@@ -64,6 +64,13 @@
             :post-affiliated :raw-value
             :structure :value :title))
 
+;;; Preliminary functions not available in raw emacs
+(defun caaddr (x)
+  (car (car (cdr (cdr x)))))
+
+(defun caddr (x)
+  (car (cdr (cdr x))))
+
 ;;;###autoload
 (defun org-to-xml (&optional filename)
   "Convert an 'org-mode' buffer to XML.


### PR DESCRIPTION
Resolves breaking error in raw emacs install (Elisp doesn't come with caaddr by default)