### PR TITLE
Update references to dependent package om.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,8 +1,6 @@
 #+TITLE: org-to-xml
 #+STARTUP: showeverything
 
-[NOTE: On 4 August 2020, the default branch was renamed to ~main~.]
-
 This project contains a library to convert Emacs org-mode files to
 XML: [[*om-to-xml][om-to-xml]].
 
@@ -10,6 +8,12 @@ The goal is a complete and accurate translation of the internal
 ~org-mode~ data structures to XML. This produces XML that isn’t
 especially pretty, but the assumption is that downstream XML
 processing tools can be used to transform it.
+
+* What’s new?
+
+** 04 August 2020
+   + Renamed default branch to ~main~.
+   + Updated dependency (the ~om.el~ package was renamed ~org-ml~)
 
 * om-to-xml
 

--- a/README.org
+++ b/README.org
@@ -1,6 +1,8 @@
 #+TITLE: org-to-xml
 #+STARTUP: showeverything
 
+[NOTE: On 4 August 2020, the default branch was renamed to ~main~.]
+
 This project contains a library to convert Emacs org-mode files to
 XML: [[*om-to-xml][om-to-xml]].
 

--- a/om-to-xml.el
+++ b/om-to-xml.el
@@ -3,7 +3,7 @@
 ;; Copyright © 2020 Norman Walsh
 
 ;; Author: Norman Walsh <ndw at nwalsh dot com>
-;; Keywords: org-mode, om, XML
+;; Keywords: org-mode, org-ml, XML
 
 ;; This file is not part of GNU Emacs.
 
@@ -22,16 +22,16 @@
 
 ;;; Prerequisites:
 
-;; om: https://github.com/ndwarshuis/om.el
+;; org-ml: https://github.com/ndwarshuis/org-ml
 
 ;;; Commentary:
 
 ;; This file converts an org-mode file to XML. It is a significant
-;; improvement over `org-to-xml.el`, also part of this package, in
-;; that it uses the excellent `om` library by Nate Dwarshuis to parse
-;; the Org data structures. I more-or-less abandoned attempting to
-;; improve `org-to-xml.el` at the point where I realized I needed a
-;; better parsing library for Org.
+;; improvement over `org-to-xml.el`, previously package, in that it
+;; uses the excellent `org-ml` library by Nate Dwarshuis to parse the
+;; Org data structures. I more-or-less abandoned attempting to improve
+;; `org-to-xml.el` at the point where I realized I needed a better
+;; parsing library for Org.
 
 ;; In addition to better parsing, `om-to-xml.el` provides a few
 ;; extensibility options:
@@ -85,14 +85,15 @@
 ;; standard about my binding.
 ;;
 ;; Change log:
-;; v0.0.1: initial release
+;; v0.0.2: Updated to use org-ml (the om.el refactored)
+;; v0.0.1: Initial release
 
 ;;; Code:
 
 (require 'org)
-(require 'om)
+(require 'org-ml)
 
-(defconst om-to-xml--om-to-xml-version "0.0.1")
+(defconst om-to-xml--om-to-xml-version "0.0.2")
 (defconst om-to-xml--om-to-xml-uri "https://github.com/ndw/org-to-xml")
 (defconst om-to-xml--namespace "https://nwalsh.com/ns/org-to-xml")
 
@@ -197,7 +198,7 @@ If no FILENAME is given, the buffer filename will be used, with
             (om-list '())
             (elem nil))
         (while (< om-point (point-max))
-          (setq elem (om-parse-element-at om-point))
+          (setq elem (org-ml-parse-element-at om-point))
           (setq parent (plist-get (cadr elem) :parent))
           (setq om-point (plist-get (cadr elem) :end))
           ;; There are places where parsing seems to get stuck.
@@ -206,7 +207,7 @@ If no FILENAME is given, the buffer filename will be used, with
           ;; :end doesn't advance the cursor position and this
           ;; while loop never ends. To avoid that, we use last-point
           ;; to force the cursor to advance.
-          ;; https://github.com/ndwarshuis/om.el/issues/8
+          ;; https://github.com/ndwarshuis/org-ml/issues/8
           (if (<= om-point last-point)
               (setq om-point (1+ last-point))
             (setq om-list (append om-list (list elem))))

--- a/om-to-xml.el
+++ b/om-to-xml.el
@@ -85,7 +85,8 @@
 ;; standard about my binding.
 ;;
 ;; Change log:
-;; v0.0.2: Updated to use org-ml (the om.el refactored)
+;; v0.0.7: Updated to use org-ml (the om.el refactored)
+;; ...
 ;; v0.0.1: Initial release
 
 ;;; Code:
@@ -93,7 +94,7 @@
 (require 'org)
 (require 'org-ml)
 
-(defconst om-to-xml--om-to-xml-version "0.0.2")
+(defconst om-to-xml--om-to-xml-version "0.0.7")
 (defconst om-to-xml--om-to-xml-uri "https://github.com/ndw/org-to-xml")
 (defconst om-to-xml--namespace "https://nwalsh.com/ns/org-to-xml")
 


### PR DESCRIPTION
The library that does the heavy lifting in this project was renamed from `om.el` to `org-ml`.

Close #6 